### PR TITLE
test: Scrub volatile factor hashes from snapshots for dev rlang

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^tools$
 ^dplyr-methods$
 ^patch$
+^patch-tests$
 ^README\.Rmd$
 ^LICENSE\.md$
 ^res-dplyr\.csv$

--- a/patch-tests/test-dplyr-all-equal.patch
+++ b/patch-tests/test-dplyr-all-equal.patch
@@ -1,0 +1,30 @@
+diff --git b/tests/testthat/test-dplyr-all-equal.R a/tests/testthat/test-dplyr-all-equal.R
+--- b/tests/testthat/test-dplyr-all-equal.R
++++ a/tests/testthat/test-dplyr-all-equal.R
+@@ -53,7 +53,7 @@ test_that("factors equal only if levels equal", {
+   local_options(lifecycle_verbosity = "quiet")
+   df1 <- tibble(x = factor(c("a", "b")))
+   df2 <- tibble(x = factor(c("a", "d")))
+-  expect_snapshot({
++  expect_snapshot(transform = scrub_hash, {
+     all_equal(df1, df2)
+     all_equal(df2, df1)
+   })
+@@ -67,7 +67,7 @@ test_that("factor comparison requires strict equality of levels (#2440)", {
+   expect_true(all_equal(df1, df2, convert = TRUE))
+   expect_true(all_equal(df2, df1, convert = TRUE))
+ 
+-  expect_snapshot({
++  expect_snapshot(transform = scrub_hash, {
+     all_equal(df1, df2)
+     all_equal(df2, df1)
+   })
+@@ -120,7 +120,7 @@ test_that("equality test fails when convert is FALSE and types don't match (#148
+   df2 <- tibble(x = factor("a"))
+   expect_true(all_equal(df1, df2, convert = TRUE))
+ 
+-  expect_snapshot({
++  expect_snapshot(transform = scrub_hash, {
+     all_equal(df1, df2, convert = FALSE)
+   })
+ })

--- a/patch-tests/test-dplyr-bind-rows.patch
+++ b/patch-tests/test-dplyr-bind-rows.patch
@@ -1,0 +1,12 @@
+diff --git b/tests/testthat/test-dplyr-bind-rows.R a/tests/testthat/test-dplyr-bind-rows.R
+--- b/tests/testthat/test-dplyr-bind-rows.R
++++ a/tests/testthat/test-dplyr-bind-rows.R
+@@ -258,7 +258,7 @@ test_that("bind_rows() accepts difftime objects", {
+ # Errors ------------------------------------------------------------
+ 
+ test_that("bind_rows() give informative errors", {
+-  expect_snapshot({
++  expect_snapshot(transform = scrub_hash, {
+     "invalid .id"
+     df1 <- tibble(x = 1:3)
+     df2 <- tibble(x = 4:6)

--- a/patch-tests/test-dplyr-case-when.patch
+++ b/patch-tests/test-dplyr-case-when.patch
@@ -1,0 +1,17 @@
+diff --git b/tests/testthat/test-dplyr-case-when.R a/tests/testthat/test-dplyr-case-when.R
+--- b/tests/testthat/test-dplyr-case-when.R
++++ a/tests/testthat/test-dplyr-case-when.R
+@@ -541,11 +541,11 @@ test_that("replace_when() retains the type of `x`", {
+   )
+ 
+   # Can't cast to unknown level
+-  expect_snapshot(error = TRUE, {
++  expect_snapshot(transform = scrub_hash, error = TRUE, {
+     replace_when(x, x == "a" ~ "d")
+   })
+   # Error index is right when `NULL` is involved
+-  expect_snapshot(error = TRUE, {
++  expect_snapshot(transform = scrub_hash, error = TRUE, {
+     replace_when(x, x == "a" ~ "b", NULL, x == "b" ~ "d")
+   })
+ })

--- a/tests/testthat/_snaps/dplyr-all-equal.md
+++ b/tests/testthat/_snaps/dplyr-all-equal.md
@@ -45,29 +45,29 @@
     Code
       all_equal(df1, df2)
     Output
-      Different types for column `x`: factor<38051> vs factor<bb232>.
+      Different types for column `x`: factor<...> vs factor<...>.
     Code
       all_equal(df2, df1)
     Output
-      Different types for column `x`: factor<bb232> vs factor<38051>.
+      Different types for column `x`: factor<...> vs factor<...>.
 
 # factor comparison requires strict equality of levels (#2440)
 
     Code
       all_equal(df1, df2)
     Output
-      Different types for column `x`: factor<4d52a> vs factor<38051>.
+      Different types for column `x`: factor<...> vs factor<...>.
     Code
       all_equal(df2, df1)
     Output
-      Different types for column `x`: factor<38051> vs factor<4d52a>.
+      Different types for column `x`: factor<...> vs factor<...>.
 
 # equality test fails when convert is FALSE and types don't match (#1484)
 
     Code
       all_equal(df1, df2, convert = FALSE)
     Output
-      Different types for column `x`: character vs factor<4d52a>.
+      Different types for column `x`: character vs factor<...>.
 
 # equality returns a message for convert = TRUE
 

--- a/tests/testthat/_snaps/dplyr-bind-rows.md
+++ b/tests/testthat/_snaps/dplyr-bind-rows.md
@@ -40,7 +40,7 @@
     Output
       <error/vctrs_error_ptype2>
       Error in `bind_rows()`:
-      ! Can't combine `..1$a` <factor<4d52a>> and `..2$a` <integer>.
+      ! Can't combine `..1$a` <factor<...>> and `..2$a` <integer>.
     Code
       # unnamed vectors
       (expect_error(bind_rows(1:2)))

--- a/tests/testthat/_snaps/dplyr-case-when.md
+++ b/tests/testthat/_snaps/dplyr-case-when.md
@@ -379,7 +379,7 @@
       replace_when(x, x == "a" ~ "d")
     Condition
       Error in `replace_when()`:
-      ! Can't convert from `..1 (right)` <character> to <factor<af15a>> due to loss of generality.
+      ! Can't convert from `..1 (right)` <character> to <factor<...>> due to loss of generality.
       * Locations: 1
 
 ---
@@ -388,7 +388,7 @@
       replace_when(x, x == "a" ~ "b", NULL, x == "b" ~ "d")
     Condition
       Error in `replace_when()`:
-      ! Can't convert from `..3 (right)` <character> to <factor<af15a>> due to loss of generality.
+      ! Can't convert from `..3 (right)` <character> to <factor<...>> due to loss of generality.
       * Locations: 1
 
 # replace_when() does not allow named `...`

--- a/tests/testthat/helper-snapshot.R
+++ b/tests/testthat/helper-snapshot.R
@@ -1,0 +1,12 @@
+# Snapshot transform that scrubs volatile hash values from snapshots.
+#
+# vctrs abbreviates factor types as `factor<xxxxx>`, where `xxxxx` is the
+# first few characters of `rlang::hash()` of the factor levels. The hash
+# algorithm is an implementation detail of rlang and changes between releases
+# (e.g. the development version of rlang uses a different walking strategy and
+# therefore produces different hashes). Scrubbing the hash keeps these
+# snapshots stable across rlang versions while still capturing the structure
+# of the message.
+scrub_hash <- function(x) {
+  gsub("factor<[0-9a-f]+>", "factor<...>", x)
+}

--- a/tests/testthat/test-dplyr-all-equal.R
+++ b/tests/testthat/test-dplyr-all-equal.R
@@ -53,7 +53,7 @@ test_that("factors equal only if levels equal", {
   local_options(lifecycle_verbosity = "quiet")
   df1 <- tibble(x = factor(c("a", "b")))
   df2 <- tibble(x = factor(c("a", "d")))
-  expect_snapshot({
+  expect_snapshot(transform = scrub_hash, {
     all_equal(df1, df2)
     all_equal(df2, df1)
   })
@@ -67,7 +67,7 @@ test_that("factor comparison requires strict equality of levels (#2440)", {
   expect_true(all_equal(df1, df2, convert = TRUE))
   expect_true(all_equal(df2, df1, convert = TRUE))
 
-  expect_snapshot({
+  expect_snapshot(transform = scrub_hash, {
     all_equal(df1, df2)
     all_equal(df2, df1)
   })
@@ -120,7 +120,7 @@ test_that("equality test fails when convert is FALSE and types don't match (#148
   df2 <- tibble(x = factor("a"))
   expect_true(all_equal(df1, df2, convert = TRUE))
 
-  expect_snapshot({
+  expect_snapshot(transform = scrub_hash, {
     all_equal(df1, df2, convert = FALSE)
   })
 })

--- a/tests/testthat/test-dplyr-bind-rows.R
+++ b/tests/testthat/test-dplyr-bind-rows.R
@@ -258,7 +258,7 @@ test_that("bind_rows() accepts difftime objects", {
 # Errors ------------------------------------------------------------
 
 test_that("bind_rows() give informative errors", {
-  expect_snapshot({
+  expect_snapshot(transform = scrub_hash, {
     "invalid .id"
     df1 <- tibble(x = 1:3)
     df2 <- tibble(x = 4:6)

--- a/tests/testthat/test-dplyr-case-when.R
+++ b/tests/testthat/test-dplyr-case-when.R
@@ -541,11 +541,11 @@ test_that("replace_when() retains the type of `x`", {
   )
 
   # Can't cast to unknown level
-  expect_snapshot(error = TRUE, {
+  expect_snapshot(transform = scrub_hash, error = TRUE, {
     replace_when(x, x == "a" ~ "d")
   })
   # Error index is right when `NULL` is involved
-  expect_snapshot(error = TRUE, {
+  expect_snapshot(transform = scrub_hash, error = TRUE, {
     replace_when(x, x == "a" ~ "b", NULL, x == "b" ~ "d")
   })
 })

--- a/tools/04-dplyr-tests.R
+++ b/tools/04-dplyr-tests.R
@@ -128,3 +128,49 @@ lock_dplyr_test <- function(path) {
 }
 
 walk(targets, lock_dplyr_test)
+
+# Patch files -------------------------------------------------------------------------
+
+# Apply manual tweaks (e.g. snapshot scrubbers) on top of the generated test
+# files, mirroring the patch workflow in 02-duckplyr_df-methods.R.
+patches <- fs::dir_ls("patch-tests")
+
+walk(
+  patches,
+  ~ system(paste0("patch -p1 < ", .x))
+)
+
+# Stop here to overwrite files if the test generation is updated
+
+# Collect new patches -----------------------------------------------------------------
+
+test_status <- gert::git_status(
+  pathspec = "tests/testthat/test-dplyr-*.R"
+)$file
+
+# Use this to refresh all patches
+# test_status <- fs::dir_ls("tests/testthat", glob = "test-dplyr-*.R")
+
+walk(test_status, function(file) {
+  patch_path <- gsub(
+    "tests/testthat/(.*)[.]R",
+    "patch-tests/\\1.patch",
+    file
+  )
+  if (fs::file_exists(patch_path)) {
+    system(paste0(
+      "patch -p1 -R < ",
+      patch_path
+    ))
+  }
+  system(paste0(
+    "git diff -R -- ",
+    file,
+    " | grep -v '^index' > ",
+    patch_path
+  ))
+  system(paste0(
+    "git checkout -- ",
+    file
+  ))
+})

--- a/tools/README.md
+++ b/tools/README.md
@@ -77,6 +77,8 @@ For each verb, creates tests that convert a data frame to a `duckplyr_df` and co
 
 Copies test files from `.sync/dplyr-main/tests/testthat/` into duckplyr's test suite as `test-dplyr-*.R`. Rewrites verb calls to use `duckplyr_<verb>()` wrappers and inserts `skip("TODO duckdb")` annotations for tests listed in `duckplyr_tests`.
 
+After writing the generated files, it applies any patch files found in `patch-tests/` (manual tweaks on top of the generated tests, e.g. snapshot scrubbers such as `transform = scrub_hash`). It then collects new patches by diffing the current test files against the generated baseline, so manual edits are preserved across regeneration. This mirrors the patch workflow of `02-duckplyr_df-methods.R`.
+
 #### `05-duckdb-tests.R`
 
 Generates `tests/testthat/test-rel_api.R`.


### PR DESCRIPTION
## Problem

The `rcc dev` CI job runs the test suite against the **development version of rlang**. Dev rlang changed its `hash()` algorithm (per its NEWS: *"all hash values will now be different"*).

vctrs abbreviates factor types as `factor<xxxxx>`, where the suffix comes from `rlang::hash()` of the factor levels. So snapshots embedding those abbreviations broke under dev rlang:

```
- Different types for column `x`: factor<38051> vs factor<bb232>.
+ Different types for column `x`: factor<3b1cd> vs factor<b99ab>.
```

Reproduced by building against both released (`1.2.0`) and dev (`1.2.0.9000`) rlang. The affected snapshots are in three vendored dplyr tests:

- `test-dplyr-all-equal.R` (3 snapshots)
- `test-dplyr-bind-rows.R` (1 snapshot)
- `test-dplyr-case-when.R` (2 snapshots)

## Fix

A snapshot scrubber, following the existing `transform =` precedent in `test-relational-duckdb.R` (which scrubs pointer addresses):

- **`tests/testthat/helper-snapshot.R`** — new `scrub_hash()` that rewrites `factor<xxxxx>` → `factor<...>`.
- Applied `transform = scrub_hash` to the six affected `expect_snapshot()` calls and updated the committed snapshots to the scrubbed form.

Since the dplyr test files are generated by `tools/04-dplyr-tests.R`, the scrubber edits are carried as **generic patch files** in a new `patch-tests/` directory, applied (and collected) after generation — mirroring the patch workflow of `tools/02-duckplyr_df-methods.R`. This keeps the fix reproducible across regeneration without special-casing the scrubber in the generator.

## Verification

- Full suite under **dev rlang** and **released rlang**: the `factor<hash>` failures are gone in both, with no regressions.
- Each patch applies cleanly with `patch -p1` to a freshly generated (pristine) test file and reproduces the committed patched version byte-for-byte.

## Out of scope

`test-fallback.R` (`wday()`/`strftime()`) also fails in this environment — `{.code wday(label = )}` now renders with backticks. This fails under **released** rlang too, so it's a pre-existing cli/dplyr formatting drift, not a dev-rlang issue, and is deliberately left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)