### PR TITLE
Add gh-fork-cleanup scripts (per-branch staleness analysis)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -24,6 +24,7 @@
 ^codecov\.yml$
 ^R/revdep\.R$
 ^gh-analysis$
+^gh-fork-cleanup$
 ^index\.md$
 ^touchstone$
 ^README_cache$

--- a/gh-fork-cleanup/README.md
+++ b/gh-fork-cleanup/README.md
@@ -54,12 +54,29 @@ are the package maintainer so they are never flagged.
 * `review-forks.txt` — the "unsure" pile; **never** auto-deleted.
 * `classified.tsv` — full `verdict <TAB> repo <TAB> reason` table for every fork.
 
+## Rate limits
+
+Analysing every branch of every fork is many API calls (one `compare` per
+branch — a fork with 100+ branches alone is 100+ calls), and firing them
+concurrently trips GitHub's *secondary* rate limit, which makes calls start
+failing mid-run. To stay safe:
+
+* The finder runs **serially by default** (`JOBS=1`). Raise it cautiously, e.g.
+  `JOBS=4 ./find-stale-forks.sh`.
+* Every API call goes through a retry wrapper with exponential backoff that
+  detects rate-limit / secondary-limit / 403 / 429 responses (`RETRIES=5` by
+  default).
+* Crucially, a fork is marked **STALE only when every branch was compared
+  *without error* and found contained.** Any throttling, compare error, empty
+  branch list, or other uncertainty downgrades the fork to **REVIEW** — so an
+  incomplete or rate-limited run can never feed a deletion.
+
 ## Caveats
 
 * Branch work that was **squash-merged** upstream shows up as unique commits, so
   the fork is flagged **REVIEW**, not STALE — by design.
+* Branches with an **unrelated history** to the base (e.g. orphan `gh-pages`)
+  report "UNRELATED history" and go to REVIEW.
 * **Private** forks are routed to REVIEW for manual inspection rather than
   compared automatically.
-* Forks with many branches mean many API calls; runs against an authenticated
-  `gh` (5000 requests/hour) but a huge account may still want to throttle.
 * Deletion is permanent. There is no undo.

--- a/gh-fork-cleanup/README.md
+++ b/gh-fork-cleanup/README.md
@@ -1,0 +1,43 @@
+# gh-fork-cleanup
+
+Helper scripts to find and delete GitHub forks that never contributed anything
+upstream. Handy when a personal account has accumulated hundreds of one-off
+forks over the years.
+
+A fork is considered **stale** (contributes nothing) when **both** hold:
+
+* its default branch is **not ahead** of the parent (`ahead_by == 0`), and
+* you have opened **no pull requests** in the parent repository.
+
+## Requirements
+
+* [`gh`](https://cli.github.com/), authenticated (`gh auth login`)
+* `jq`
+* `delete_repo` scope for the deletion step:
+  `gh auth refresh -h github.com -s delete_repo`
+
+## Usage
+
+```bash
+# 1. Produce the candidate list -> stale-forks.txt
+./find-stale-forks.sh
+
+# 2. REVIEW the list by hand before deleting anything.
+cat stale-forks.txt
+
+# 3. Delete everything in the list (irreversible).
+./delete-stale-forks.sh
+```
+
+Set `USER=` at the top of `find-stale-forks.sh` to target a different account
+(defaults to `krlmlr`). The `KEEP` allow-list protects repositories where you
+are the package maintainer so they are never flagged.
+
+## Caveats
+
+* Only the **default branch** is compared against the parent. A fork that
+  carries work on a non-default branch but never opened a PR for it is reported
+  as stale — review the list before deleting.
+* **Private** forks are intentionally excluded from the automated comparison;
+  audit those manually.
+* Deletion is permanent. There is no undo.

--- a/gh-fork-cleanup/README.md
+++ b/gh-fork-cleanup/README.md
@@ -4,10 +4,22 @@ Helper scripts to find and delete GitHub forks that never contributed anything
 upstream. Handy when a personal account has accumulated hundreds of one-off
 forks over the years.
 
-A fork is considered **stale** (contributes nothing) when **both** hold:
+`find-stale-forks.sh` analyses **every branch** of each fork and compares it
+against the upstream parent (against the upstream branch of the same name when
+one exists, otherwise the upstream default branch). It sorts each fork into one
+of three buckets:
 
-* its default branch is **not ahead** of the parent (`ahead_by == 0`), and
-* you have opened **no pull requests** in the parent repository.
+| Verdict    | Meaning                                                                                   | Output             |
+|------------|-------------------------------------------------------------------------------------------|--------------------|
+| **STALE**  | every branch is fully contained in upstream (`ahead_by == 0`) **and** you opened no PRs   | `stale-forks.txt`  |
+| **KEEP**   | every branch is contained, but you authored pull request(s) upstream                      | (none)             |
+| **REVIEW** | ≥1 branch has commit(s) not in upstream, or the fork is private / detached / errored      | `review-forks.txt` |
+
+A branch with commits that are *not* present in upstream lands the fork in
+**REVIEW** rather than STALE. The code on such a branch might still be in
+upstream (e.g. it was squash-merged, so the commits differ), which the
+commit-level comparison can't tell — so REVIEW is the "unsure" bucket. Point an
+LLM (or your own eyes) at those repos before deciding.
 
 ## Requirements
 
@@ -19,13 +31,15 @@ A fork is considered **stale** (contributes nothing) when **both** hold:
 ## Usage
 
 ```bash
-# 1. Produce the candidate list -> stale-forks.txt
+# 1. Analyse all forks. Verbose per-branch output goes to stderr; pass -q to
+#    silence it. Produces stale-forks.txt, review-forks.txt and classified.tsv.
 ./find-stale-forks.sh
 
-# 2. REVIEW the list by hand before deleting anything.
+# 2. REVIEW the candidate list (and the unsure pile) before deleting anything.
 cat stale-forks.txt
+cat review-forks.txt
 
-# 3. Delete everything in the list (irreversible).
+# 3. Delete everything in stale-forks.txt (irreversible).
 ./delete-stale-forks.sh
 ```
 
@@ -33,11 +47,19 @@ Set `USER=` at the top of `find-stale-forks.sh` to target a different account
 (defaults to `krlmlr`). The `KEEP` allow-list protects repositories where you
 are the package maintainer so they are never flagged.
 
+## Output files
+
+* `stale-forks.txt` — deletable forks, one `owner/repo` per line; the only input
+  to `delete-stale-forks.sh`.
+* `review-forks.txt` — the "unsure" pile; **never** auto-deleted.
+* `classified.tsv` — full `verdict <TAB> repo <TAB> reason` table for every fork.
+
 ## Caveats
 
-* Only the **default branch** is compared against the parent. A fork that
-  carries work on a non-default branch but never opened a PR for it is reported
-  as stale — review the list before deleting.
-* **Private** forks are intentionally excluded from the automated comparison;
-  audit those manually.
+* Branch work that was **squash-merged** upstream shows up as unique commits, so
+  the fork is flagged **REVIEW**, not STALE — by design.
+* **Private** forks are routed to REVIEW for manual inspection rather than
+  compared automatically.
+* Forks with many branches mean many API calls; runs against an authenticated
+  `gh` (5000 requests/hour) but a huge account may still want to throttle.
 * Deletion is permanent. There is no undo.

--- a/gh-fork-cleanup/delete-stale-forks.sh
+++ b/gh-fork-cleanup/delete-stale-forks.sh
@@ -2,7 +2,8 @@
 # delete-stale-forks.sh
 # Stupid + loop-free: deletes every repo listed in stale-forks.txt.
 #
-#   1. Run ./find-stale-forks.sh first.
+#   1. Run ./find-stale-forks.sh first (it also writes review-forks.txt, the
+#      "unsure" pile, which this script deliberately ignores).
 #   2. REVIEW stale-forks.txt by hand.
 #   3. Make sure gh has the delete scope:  gh auth refresh -h github.com -s delete_repo
 #   4. Run this.

--- a/gh-fork-cleanup/delete-stale-forks.sh
+++ b/gh-fork-cleanup/delete-stale-forks.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# delete-stale-forks.sh
+# Stupid + loop-free: deletes every repo listed in stale-forks.txt.
+#
+#   1. Run ./find-stale-forks.sh first.
+#   2. REVIEW stale-forks.txt by hand.
+#   3. Make sure gh has the delete scope:  gh auth refresh -h github.com -s delete_repo
+#   4. Run this.
+set -euo pipefail
+xargs -r -I{} gh repo delete {} --yes < stale-forks.txt

--- a/gh-fork-cleanup/find-stale-forks.sh
+++ b/gh-fork-cleanup/find-stale-forks.sh
@@ -4,17 +4,23 @@
 # Classifies every (non-archived) fork on your account by analysing ALL of its
 # branches against the upstream parent:
 #
-#   STALE   every branch is fully contained in upstream (0 commits ahead) AND
-#           you opened no pull requests upstream  -> safe to delete.
+#   STALE   every branch was successfully compared AND is fully contained in
+#           upstream (0 commits ahead) AND you opened no pull requests upstream.
+#           Only this bucket is safe to delete.
 #   KEEP    every branch is contained, but you DID open PR(s) upstream.
-#   REVIEW  at least one branch has commit(s) not present in upstream, OR the
-#           fork is private / detached / errored. The code *might* still be in
-#           upstream (e.g. squash-merged), so this is the "unsure" bucket --
-#           point an LLM (or your eyes) at the repo before deciding.
+#   REVIEW  at least one branch has commit(s) not present in upstream, OR has an
+#           unrelated history, OR the fork is private / detached, OR *anything
+#           could not be determined* (branch list empty, compare errored). The
+#           code might still be in upstream (e.g. squash-merged) -- so this is
+#           the "unsure" bucket: point an LLM (or your eyes) at the repo.
 #
 # Each fork branch is compared against the upstream branch of the SAME name when
 # one exists, otherwise against the upstream default branch. "ahead_by == 0"
 # means every commit on that branch already exists in upstream.
+#
+# SAFETY: a fork is classified STALE only when *every* branch was compared
+# without error and found contained. Any error/uncertainty -> REVIEW, never
+# STALE, so an incomplete run can never feed a delete.
 #
 # Outputs (machine-readable, one "owner/repo" per line):
 #   stale-forks.txt    -> fed to delete-stale-forks.sh
@@ -24,58 +30,102 @@
 # Verbose per-branch analysis is printed to stderr (on by default; -q silences).
 #
 # Requires: gh (authenticated), jq. Portable to bash 3.2 (macOS).
+#
+# Tuning via env:
+#   JOBS=N      parallel forks (default 1 -- serial, to avoid GitHub's secondary
+#               rate limit; raise cautiously, the retry/backoff below helps).
+#   RETRIES=N   per-call retries on throttling (default 5).
 set -uo pipefail
 
 USER=krlmlr
 VERBOSE=1
+JOBS="${JOBS:-1}"
+RETRIES="${RETRIES:-5}"
 { [ "${1:-}" = "-q" ] || [ "${1:-}" = "--quiet" ]; } && VERBOSE=0
 
 # Never touch these: packages where you are the DESCRIPTION Maintainer.
 KEEP='backends blob DBI DBItest dblog duckplyr here hms jointprof LoadMyData
 pillar profile RKazam RMariaDB roxygen2md RSQLite tibble tic tkigraph travis'
 
+# gh api with retry + exponential backoff on rate/secondary limits.
+# Prints body to stdout. Returns: 0 ok, 1 non-throttle HTTP error (body is the
+# error JSON), 2 throttled past RETRIES.
+ghapi() {
+  local out err rc attempt=0 delay=3
+  err="$(mktemp)"
+  while :; do
+    out="$(gh api "$@" 2>"$err")"; rc=$?
+    if [ "$rc" -eq 0 ]; then rm -f "$err"; printf '%s' "$out"; return 0; fi
+    if grep -qiE 'rate limit|secondary rate|abuse detection|retry-after|HTTP 403|HTTP 429' "$err"; then
+      attempt=$((attempt + 1))
+      if [ "$attempt" -gt "$RETRIES" ]; then rm -f "$err"; return 2; fi
+      sleep "$delay"; delay=$((delay * 2)); continue
+    fi
+    rm -f "$err"; printf '%s' "$out"; return 1   # genuine 404 etc.; body returned
+  done
+}
+
+# Percent-encode the characters that break a compare ref in the URL path.
+urlenc() { printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/#/%23/g' -e 's/ /%20/g' -e 's/?/%3F/g'; }
+
 check() {
-  local repo="$1" full meta priv parent base uptmp b cmpbase ahead behind status
-  local unique=0 nbranch=0 details="" prs
+  local repo="$1" full meta priv parent base uptmp fbtmp b cmpbase resp ahead behind msg
+  local unique=0 errors=0 nbranch=0 details=""
   full="$USER/$repo"
   v() { [ "${VERBOSE:-1}" = 1 ] && printf '[%s] %s\n' "$repo" "$*" >&2; }
 
-  meta=$(gh api "repos/$full" --jq '[.private, (.parent.full_name // ""), (.parent.default_branch // "")] | @tsv' 2>/dev/null) \
+  meta="$(ghapi "repos/$full" --jq '[.private, (.parent.full_name // ""), (.parent.default_branch // "")] | @tsv')" \
     || { v "metadata fetch failed -> REVIEW"; printf 'REVIEW\t%s\tmetadata-error\n' "$full"; return; }
   IFS=$'\t' read -r priv parent base <<<"$meta"
 
   if [ -z "$parent" ]; then v "no upstream parent (detached) -> REVIEW"; printf 'REVIEW\t%s\tno-parent\n' "$full"; return; fi
   if [ "$priv" = "true" ]; then v "private repo -> REVIEW (inspect manually)"; printf 'REVIEW\t%s\tprivate\n' "$full"; return; fi
 
-  uptmp=$(mktemp)
-  gh api "repos/$parent/branches" --paginate --jq '.[].name' >"$uptmp" 2>/dev/null
+  uptmp="$(mktemp)"; fbtmp="$(mktemp)"
+  ghapi "repos/$parent/branches" --paginate --jq '.[].name' >"$uptmp" 2>/dev/null
+  if ! ghapi "repos/$full/branches" --paginate --jq '.[].name' >"$fbtmp" 2>/dev/null; then
+    v "could not list fork branches -> REVIEW"; rm -f "$uptmp" "$fbtmp"
+    printf 'REVIEW\t%s\tbranch-list-error\n' "$full"; return
+  fi
 
   v "upstream=$parent default=$base"
-  while IFS= read -r b; do
+  while IFS= read -r b || [ -n "$b" ]; do
     [ -z "$b" ] && continue
     nbranch=$((nbranch + 1))
     if grep -qxF -- "$b" "$uptmp"; then cmpbase="$b"; else cmpbase="$base"; fi
-    IFS=$'\t' read -r ahead behind status < <(
-      gh api "repos/$parent/compare/$cmpbase...$USER:$b" --jq '[.ahead_by, .behind_by, .status] | @tsv' 2>/dev/null \
-      || printf '?\t?\terror\n'
-    )
+    resp="$(ghapi "repos/$parent/compare/$(urlenc "$cmpbase")...$USER:$(urlenc "$b")")"
+    ahead="$(printf '%s' "$resp" | jq -r 'if type=="object" then (.ahead_by // empty) else empty end' 2>/dev/null)"
+    behind="$(printf '%s' "$resp" | jq -r 'if type=="object" then (.behind_by // empty) else empty end' 2>/dev/null)"
     if [ "$ahead" = "0" ]; then
       v "  branch '$b'  vs $parent:$cmpbase  -> contained (behind ${behind:-?})"
-    elif [ "$ahead" = "?" ] || [ -z "$ahead" ]; then
-      v "  branch '$b'  vs $parent:$cmpbase  -> COMPARE FAILED [review]"
-      unique=$((unique + 1)); details="$details $b(?)"
-    else
+    elif printf '%s' "$resp" | grep -q 'No common ancestor'; then
+      v "  branch '$b'  vs $parent:$cmpbase  -> UNRELATED history [review]"
+      unique=$((unique + 1)); details="$details $b(unrelated)"
+    elif [ -n "$ahead" ]; then
       v "  branch '$b'  vs $parent:$cmpbase  -> $ahead commit(s) NOT in upstream [review]"
       unique=$((unique + 1)); details="$details $b(+$ahead)"
+    else
+      msg="$(printf '%s' "$resp" | jq -r '.message? // "compare-failed"' 2>/dev/null | head -1)"
+      v "  branch '$b'  vs $parent:$cmpbase  -> COMPARE ERROR: ${msg:-unknown} [review]"
+      errors=$((errors + 1)); details="$details $b(err)"
     fi
-  done < <(gh api "repos/$full/branches" --paginate --jq '.[].name' 2>/dev/null)
-  rm -f "$uptmp"
+  done <"$fbtmp"
+  rm -f "$uptmp" "$fbtmp"
 
-  prs=$(gh pr list --repo "$parent" --author "$USER" --state all --limit 100 --json number --jq 'length' 2>/dev/null || echo 0)
+  local prs
+  prs="$(gh pr list --repo "$parent" --author "$USER" --state all --limit 100 --json number --jq 'length' 2>/dev/null || echo '?')"
 
-  if [ "$unique" -gt 0 ]; then
-    v "VERDICT: REVIEW  ($unique/$nbranch branch(es) with unique commits:$details )"
-    printf 'REVIEW\t%s\tunique:%s\n' "$full" "$(echo "$details" | tr -s ' ' ',' | sed 's/^,//')"
+  details="$(echo "$details" | tr -s ' ' ',' | sed 's/^,//')"
+
+  if [ "$nbranch" -eq 0 ]; then
+    v "VERDICT: REVIEW  (no branches enumerated -- cannot conclude)"
+    printf 'REVIEW\t%s\tno-branches-enumerated\n' "$full"
+  elif [ "$errors" -gt 0 ] || ! [ "$prs" -ge 0 ] 2>/dev/null; then
+    v "VERDICT: REVIEW  (incomplete: $errors/$nbranch compare error(s), $unique unique, prs=$prs)"
+    printf 'REVIEW\t%s\tincomplete:%s\n' "$full" "$details"
+  elif [ "$unique" -gt 0 ]; then
+    v "VERDICT: REVIEW  ($unique/$nbranch branch(es) with unique commits: $details )"
+    printf 'REVIEW\t%s\tunique:%s\n' "$full" "$details"
   elif [ "$prs" != "0" ]; then
     v "VERDICT: KEEP  (all $nbranch branch(es) contained, but $prs PR(s) authored upstream)"
     printf 'KEEP\t%s\t%s-prs\n' "$full" "$prs"
@@ -84,14 +134,14 @@ check() {
     printf 'STALE\t%s\t%s-branches\n' "$full" "$nbranch"
   fi
 }
-export -f check
-export USER VERBOSE
+export -f check ghapi urlenc
+export USER VERBOSE RETRIES
 
 # Loop-free fan-out: gh lists the forks, grep drops the keepers, xargs runs the
-# per-fork analysis across workers. Verdicts -> classified.tsv.
+# per-fork analysis. Default JOBS=1 (serial) to stay under the secondary limit.
 gh repo list "$USER" --fork --no-archived --limit 1000 --json name --jq '.[].name' \
   | grep -vxF -f <(printf '%s\n' $KEEP) \
-  | xargs -P 6 -I{} bash -c 'check "$@"' _ {} \
+  | xargs -P "$JOBS" -I{} bash -c 'check "$@"' _ {} \
   | sort -u > classified.tsv
 
 grep '^STALE'  classified.tsv | cut -f2 > stale-forks.txt

--- a/gh-fork-cleanup/find-stale-forks.sh
+++ b/gh-fork-cleanup/find-stale-forks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# find-stale-forks.sh
+# Lists your forks that contribute NOTHING upstream:
+#   * their default branch is NOT ahead of the parent (ahead_by == 0), AND
+#   * you have opened NO pull requests in the parent repo.
+# Output: one "krlmlr/<repo>" per line, on stdout and into stale-forks.txt
+#
+# Requires: gh (authenticated), jq
+# Caveat: only the DEFAULT branch is compared. A fork that carries work on a
+#         non-default branch (but never PR'd it) is treated as "stale". Eyeball
+#         stale-forks.txt before deleting.
+set -euo pipefail
+
+USER=krlmlr
+
+# Never touch these: packages where you are the DESCRIPTION Maintainer.
+KEEP='backends blob DBI DBItest dblog duckplyr here hms jointprof LoadMyData
+pillar profile RKazam RMariaDB roxygen2md RSQLite tibble tic tkigraph travis'
+
+check() {
+  local repo="$1" full parent base head ahead prs
+  full="krlmlr/$repo"
+  read -r parent base head < <(
+    gh api "repos/$full" --jq '[.parent.full_name, .parent.default_branch, .default_branch] | @tsv'
+  ) || return 0
+  [ -z "$parent" ] && return 0                                  # not a fork
+  ahead=$(gh api "repos/$parent/compare/$base...krlmlr:$head" --jq '.ahead_by' 2>/dev/null || echo '?')
+  prs=$(gh pr list --repo "$parent" --author "$USER" --state all --limit 100 --json number --jq 'length' 2>/dev/null || echo 0)
+  [ "$ahead" = "0" ] && [ "$prs" = "0" ] && echo "$full"
+}
+export -f check
+export USER
+
+# Loop-free pipeline: gh enumerates the forks, grep drops the keepers,
+# xargs fans the per-fork check out across 8 workers.
+gh repo list "$USER" --fork --no-archived --limit 1000 --json name --jq '.[].name' \
+  | grep -vxF -f <(printf '%s\n' $KEEP) \
+  | xargs -P 8 -I{} bash -c 'check "$@"' _ {} \
+  | sort | tee stale-forks.txt

--- a/gh-fork-cleanup/find-stale-forks.sh
+++ b/gh-fork-cleanup/find-stale-forks.sh
@@ -1,39 +1,103 @@
 #!/usr/bin/env bash
 # find-stale-forks.sh
-# Lists your forks that contribute NOTHING upstream:
-#   * their default branch is NOT ahead of the parent (ahead_by == 0), AND
-#   * you have opened NO pull requests in the parent repo.
-# Output: one "krlmlr/<repo>" per line, on stdout and into stale-forks.txt
 #
-# Requires: gh (authenticated), jq
-# Caveat: only the DEFAULT branch is compared. A fork that carries work on a
-#         non-default branch (but never PR'd it) is treated as "stale". Eyeball
-#         stale-forks.txt before deleting.
-set -euo pipefail
+# Classifies every (non-archived) fork on your account by analysing ALL of its
+# branches against the upstream parent:
+#
+#   STALE   every branch is fully contained in upstream (0 commits ahead) AND
+#           you opened no pull requests upstream  -> safe to delete.
+#   KEEP    every branch is contained, but you DID open PR(s) upstream.
+#   REVIEW  at least one branch has commit(s) not present in upstream, OR the
+#           fork is private / detached / errored. The code *might* still be in
+#           upstream (e.g. squash-merged), so this is the "unsure" bucket --
+#           point an LLM (or your eyes) at the repo before deciding.
+#
+# Each fork branch is compared against the upstream branch of the SAME name when
+# one exists, otherwise against the upstream default branch. "ahead_by == 0"
+# means every commit on that branch already exists in upstream.
+#
+# Outputs (machine-readable, one "owner/repo" per line):
+#   stale-forks.txt    -> fed to delete-stale-forks.sh
+#   review-forks.txt   -> NEVER auto-deleted; inspect by hand / with an LLM
+#   classified.tsv     -> full <verdict>\t<repo>\t<reason> table
+#
+# Verbose per-branch analysis is printed to stderr (on by default; -q silences).
+#
+# Requires: gh (authenticated), jq. Portable to bash 3.2 (macOS).
+set -uo pipefail
 
 USER=krlmlr
+VERBOSE=1
+{ [ "${1:-}" = "-q" ] || [ "${1:-}" = "--quiet" ]; } && VERBOSE=0
 
 # Never touch these: packages where you are the DESCRIPTION Maintainer.
 KEEP='backends blob DBI DBItest dblog duckplyr here hms jointprof LoadMyData
 pillar profile RKazam RMariaDB roxygen2md RSQLite tibble tic tkigraph travis'
 
 check() {
-  local repo="$1" full parent base head ahead prs
-  full="krlmlr/$repo"
-  read -r parent base head < <(
-    gh api "repos/$full" --jq '[.parent.full_name, .parent.default_branch, .default_branch] | @tsv'
-  ) || return 0
-  [ -z "$parent" ] && return 0                                  # not a fork
-  ahead=$(gh api "repos/$parent/compare/$base...krlmlr:$head" --jq '.ahead_by' 2>/dev/null || echo '?')
+  local repo="$1" full meta priv parent base uptmp b cmpbase ahead behind status
+  local unique=0 nbranch=0 details="" prs
+  full="$USER/$repo"
+  v() { [ "${VERBOSE:-1}" = 1 ] && printf '[%s] %s\n' "$repo" "$*" >&2; }
+
+  meta=$(gh api "repos/$full" --jq '[.private, (.parent.full_name // ""), (.parent.default_branch // "")] | @tsv' 2>/dev/null) \
+    || { v "metadata fetch failed -> REVIEW"; printf 'REVIEW\t%s\tmetadata-error\n' "$full"; return; }
+  IFS=$'\t' read -r priv parent base <<<"$meta"
+
+  if [ -z "$parent" ]; then v "no upstream parent (detached) -> REVIEW"; printf 'REVIEW\t%s\tno-parent\n' "$full"; return; fi
+  if [ "$priv" = "true" ]; then v "private repo -> REVIEW (inspect manually)"; printf 'REVIEW\t%s\tprivate\n' "$full"; return; fi
+
+  uptmp=$(mktemp)
+  gh api "repos/$parent/branches" --paginate --jq '.[].name' >"$uptmp" 2>/dev/null
+
+  v "upstream=$parent default=$base"
+  while IFS= read -r b; do
+    [ -z "$b" ] && continue
+    nbranch=$((nbranch + 1))
+    if grep -qxF -- "$b" "$uptmp"; then cmpbase="$b"; else cmpbase="$base"; fi
+    IFS=$'\t' read -r ahead behind status < <(
+      gh api "repos/$parent/compare/$cmpbase...$USER:$b" --jq '[.ahead_by, .behind_by, .status] | @tsv' 2>/dev/null \
+      || printf '?\t?\terror\n'
+    )
+    if [ "$ahead" = "0" ]; then
+      v "  branch '$b'  vs $parent:$cmpbase  -> contained (behind ${behind:-?})"
+    elif [ "$ahead" = "?" ] || [ -z "$ahead" ]; then
+      v "  branch '$b'  vs $parent:$cmpbase  -> COMPARE FAILED [review]"
+      unique=$((unique + 1)); details="$details $b(?)"
+    else
+      v "  branch '$b'  vs $parent:$cmpbase  -> $ahead commit(s) NOT in upstream [review]"
+      unique=$((unique + 1)); details="$details $b(+$ahead)"
+    fi
+  done < <(gh api "repos/$full/branches" --paginate --jq '.[].name' 2>/dev/null)
+  rm -f "$uptmp"
+
   prs=$(gh pr list --repo "$parent" --author "$USER" --state all --limit 100 --json number --jq 'length' 2>/dev/null || echo 0)
-  [ "$ahead" = "0" ] && [ "$prs" = "0" ] && echo "$full"
+
+  if [ "$unique" -gt 0 ]; then
+    v "VERDICT: REVIEW  ($unique/$nbranch branch(es) with unique commits:$details )"
+    printf 'REVIEW\t%s\tunique:%s\n' "$full" "$(echo "$details" | tr -s ' ' ',' | sed 's/^,//')"
+  elif [ "$prs" != "0" ]; then
+    v "VERDICT: KEEP  (all $nbranch branch(es) contained, but $prs PR(s) authored upstream)"
+    printf 'KEEP\t%s\t%s-prs\n' "$full" "$prs"
+  else
+    v "VERDICT: STALE  (all $nbranch branch(es) contained, no PRs)"
+    printf 'STALE\t%s\t%s-branches\n' "$full" "$nbranch"
+  fi
 }
 export -f check
-export USER
+export USER VERBOSE
 
-# Loop-free pipeline: gh enumerates the forks, grep drops the keepers,
-# xargs fans the per-fork check out across 8 workers.
+# Loop-free fan-out: gh lists the forks, grep drops the keepers, xargs runs the
+# per-fork analysis across workers. Verdicts -> classified.tsv.
 gh repo list "$USER" --fork --no-archived --limit 1000 --json name --jq '.[].name' \
   | grep -vxF -f <(printf '%s\n' $KEEP) \
-  | xargs -P 8 -I{} bash -c 'check "$@"' _ {} \
-  | sort | tee stale-forks.txt
+  | xargs -P 6 -I{} bash -c 'check "$@"' _ {} \
+  | sort -u > classified.tsv
+
+grep '^STALE'  classified.tsv | cut -f2 > stale-forks.txt
+grep '^REVIEW' classified.tsv | cut -f2 > review-forks.txt
+
+printf '\n=== summary ===\n' >&2
+printf 'STALE  (deletable): %s -> stale-forks.txt\n'  "$(grep -c '^STALE'  classified.tsv)" >&2
+printf 'REVIEW (unsure)   : %s -> review-forks.txt\n' "$(grep -c '^REVIEW' classified.tsv)" >&2
+printf 'KEEP   (has PRs)  : %s\n'                      "$(grep -c '^KEEP'   classified.tsv)" >&2


### PR DESCRIPTION
Adds a self-contained `gh-fork-cleanup/` directory with helper scripts for pruning GitHub forks that never contributed anything upstream.

`find-stale-forks.sh` analyses **every branch** of each fork, comparing it against the upstream parent (the upstream branch of the same name when one exists, otherwise the default branch). Each fork is sorted into:

| Verdict | Meaning | Output |
|---|---|---|
| **STALE** | every branch compared without error **and** fully contained in upstream (`ahead_by == 0`) **and** no PRs by you | `stale-forks.txt` |
| **KEEP** | every branch contained, but you authored PR(s) upstream | — |
| **REVIEW** | ≥1 branch has commits not in upstream / an unrelated history, the fork is private / detached, **or anything could not be determined** | `review-forks.txt` |

### Safety & rate limits
Analysing all branches is many API calls, and firing them concurrently trips GitHub's *secondary* rate limit. The finder therefore:
- runs **serially by default** (`JOBS=1`, configurable), with a retry/backoff wrapper that detects rate-limit / 403 / 429 and retries (`RETRIES=5`);
- marks a fork **STALE only when every branch was compared without error and found contained** — any throttling, compare error, empty branch list, or failed PR lookup downgrades to REVIEW, so an incomplete run can never feed a deletion;
- URL-encodes branch names (so `#` etc. don't truncate the compare URL) and parses compare responses as JSON locally (no error-body leakage; "No common ancestor" → UNRELATED history).

### Files
- **`find-stale-forks.sh`** — loop-free fan-out (`gh repo list … | grep | xargs`); verbose per-branch analysis to stderr (`-q` to silence); writes `stale-forks.txt`, `review-forks.txt`, and a full `classified.tsv` verdict table. A `KEEP` allow-list protects packages where you are the maintainer.
- **`delete-stale-forks.sh`** — the deletion step: `xargs -I{} gh repo delete {} --yes < stale-forks.txt` (ignores `review-forks.txt`).
- **`README.md`** — usage, requirements (`gh`, `jq`, `delete_repo` scope), output files, rate-limit notes, and caveats.

Added to `.Rbuildignore` so it is excluded from the package build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HH8JNcYX67WbJn3SiiHecz