### PR TITLE
docs: make the `dd$` escape hatch discoverable

### DIFF
--- a/vignettes/duckdb.Rmd
+++ b/vignettes/duckdb.Rmd
@@ -109,6 +109,11 @@ duckdb_tibble(a = 2L, b = 3L) %>%
   mutate(c = dd$least_common_multiple(a, b))
 ```
 
+`dd` here is not a real object and does not need to be defined, imported, or attached: `dd$fun(...)` is recognized syntactically by duckplyr's translator, which passes `fun` to DuckDB verbatim (DuckDB validates the name).
+No extra package is required to use the escape hatch.
+Introspection therefore does not reveal it: `?dd`, `duckplyr::dd`, and `ls("package:duckplyr")` all come up empty even though `dd$fun(...)` works.
+The optional [dd package](https://github.com/cynkra/dd) described below is what provides a real `dd` object, `?dd`, and autocomplete.
+
 The `dd` prefix has been picked for the following reasons:
 
 - it is an abbreviation of "DuckDB"

--- a/vignettes/limits.Rmd
+++ b/vignettes/limits.Rmd
@@ -95,6 +95,9 @@ For all functions used in dplyr verbs, translations must be provided.
 If an expression contains a function for which no translation is provided, duckplyr falls back to dplyr.
 With some exceptions, only positional matching is implemented.
 
+If a function is not translated but the corresponding DuckDB function is known, the translation layer can be bypassed with the `dd$` escape hatch, e.g. `summarise(v = dd$var_samp(x))` to reach DuckDB's `var_samp()` (which dplyr's `var()` does not map to).
+See `vignette("duckdb")` for details.
+
 As of now, here are the translations provided:
 
 ### Parentheses


### PR DESCRIPTION
## Why

`dd$fun(...)` is a purely syntactic passthrough recognized by the translator (`R/translate.R`): there is **no `dd` object**. So the natural discovery moves all fail —

```r
?dd                      # no help topic
duckplyr::dd             # 'dd' is not an exported object from 'namespace:duckplyr'
ls("package:duckplyr")   # nothing
getNamespaceExports("duckplyr")  # nothing
```

— even though `dd$var_samp(x)` works. It's easy to conclude the feature is absent (I did, while using duckplyr from another project, and fell back to a `sd()^2` workaround before finding the escape hatch documented only in `vignette("duckdb")` + NEWS #658).

The mechanism is well explained in `vignette("duckdb")`, but only there, and only as prose — nothing surfaces it when a user hits an untranslated function or introspects the package.

## What changes (docs only)

- **`vignettes/duckdb.Rmd`** — state explicitly that `dd` is not a real object and needs no package (introspection won't reveal it), and that the optional [dd package](https://github.com/cynkra/dd) is what provides the real `dd` object, `?dd`, and autocomplete. This targets the exact wrong assumption ("I need a `dd` object").
- **`vignettes/limits.Rmd`** — at the point where untranslatable functions are discussed, point to the `dd$` escape hatch as the way to reach the DuckDB function directly (e.g. `dd$var_samp()` for dplyr's untranslated `var()`), linking `vignette("duckdb")`.

## Decomposition (duckplyr vs dd)

- **duckplyr** owns the passthrough *mechanism*; its docs should explain it and point to the catalog. That's this PR.
- **`dd`** owns the *catalog*: the real `dd` object, `?dd`, and per-function docs generated from DuckDB. Left as-is; this PR just references it.

## Considered but intentionally not done

- **Adding a hint to the `"Can't translate function"` abort** would be the highest-leverage fix (it fires exactly when a user needs the escape hatch). But that message is recorded verbatim in the fallback telemetry (`R/telemetry.R` → `conditionMessage(cnd)`), which the translation-prioritization analysis keys on, and it's snapshotted in `_snaps/translate.md` and `_snaps/fallback.md`. Changing it would pollute that stream, so I left it to your judgment.
- **`NEWS.md`** is fledge-managed ("contributors should not edit"), so untouched.
- **A `?dd` help page in duckplyr** would clash with the `dd` package's `?dd`; per the decomposition above, that stays in `dd`.

No code, tests, or snapshots touched — vignette prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtDe7DZz9Bb8VjmsTWFiH7)_