### PR TITLE
ci: Fix continuous benchmark (touchstone) workflow

### DIFF
--- a/.github/workflows/touchstone-comment.yaml
+++ b/.github/workflows/touchstone-comment.yaml
@@ -10,6 +10,13 @@ on:
     types:
       - completed
 
+permissions:
+  # `comment` posts the benchmark results as a PR comment and sets a commit
+  # status; the default read-only GITHUB_TOKEN cannot do either.
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   upload:
     runs-on: ubuntu-24.04

--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -26,3 +26,14 @@ jobs:
       - uses: lorenzwalthert/touchstone/actions/receive@main
         with:
           cache-version: 1
+          # Packages needed by the benchmark harness that aren't installed via
+          # the package's own dependencies:
+          # - qs2 is declared under Enhances (not installed by default) and is
+          #   used to cache the TPC-H tables (touchstone/script.R,
+          #   tools/31-tpch-load-qs.R).
+          # - pkgload and fs are undeclared but used by the data-generation
+          #   scripts (tools/30-tpch-export.R, tools/31-tpch-load-qs.R).
+          extra-packages: |
+            any::qs2
+            any::pkgload
+            any::fs

--- a/tools/31-tpch-load-qs.R
+++ b/tools/31-tpch-load-qs.R
@@ -11,13 +11,22 @@ tables <- c(
   "region"
 )
 
+# Materialize each table with `dplyr::collect()` before saving.
+# `read_parquet_duckdb()` returns a lazy, DuckDB-backed `duckplyr_df`.
+# qs2 can round-trip such an object, but it comes back as a materialized data
+# frame that still carries the `duckplyr_df` class and explicit row names.
+# The benchmark script then calls `as_duckdb_tibble()` on it, which fails with
+# "Need data frame without row names to convert to relational".
+# Collecting to a plain tibble up front avoids this.
 data <- lapply(tables, function(t) {
-  duckplyr::read_parquet_duckdb(
-    fs::path(
-      "tools/tpch/001",
-      paste0(t, ".parquet")
-    ),
-    prudence = "lavish"
+  dplyr::collect(
+    duckplyr::read_parquet_duckdb(
+      fs::path(
+        "tools/tpch/001",
+        paste0(t, ".parquet")
+      ),
+      prudence = "lavish"
+    )
   )
 })
 
@@ -29,12 +38,14 @@ qs2::qs_save(
 )
 
 data <- lapply(tables, function(t) {
-  duckplyr::read_parquet_duckdb(
-    fs::path(
-      "tools/tpch/010",
-      paste0(t, ".parquet")
-    ),
-    prudence = "lavish"
+  dplyr::collect(
+    duckplyr::read_parquet_duckdb(
+      fs::path(
+        "tools/tpch/010",
+        paste0(t, ".parquet")
+      ),
+      prudence = "lavish"
+    )
   )
 })
 
@@ -46,12 +57,14 @@ qs2::qs_save(
 )
 
 data <- lapply(tables, function(t) {
-  duckplyr::read_parquet_duckdb(
-    fs::path(
-      "tools/tpch/100",
-      paste0(t, ".parquet")
-    ),
-    prudence = "lavish"
+  dplyr::collect(
+    duckplyr::read_parquet_duckdb(
+      fs::path(
+        "tools/tpch/100",
+        paste0(t, ".parquet")
+      ),
+      prudence = "lavish"
+    )
   )
 })
 


### PR DESCRIPTION
## Problem

The continuous benchmark workflow (touchstone) could not run to completion.
Three independent defects, each fixed here.

## Changes

### 1. Install the packages the benchmark actually needs (`touchstone-receive.yaml`)

`touchstone/script.R` and its data-generation helpers use `qs2`, `pkgload`,
and `fs`, but the `receive` action never installs them:

- `qs2` is declared under `Enhances` in `DESCRIPTION`,
  which `setup-r-dependencies` does not install by default,
  so `qs2::qs_read()` / `qs2::qs_save()` fail.
- `pkgload` and `fs` are not declared anywhere,
  but `tools/30-tpch-export.R` and `tools/31-tpch-load-qs.R` use them.

Added an `extra-packages` block (`any::qs2`, `any::pkgload`, `any::fs`).

### 2. Cache plain tibbles, not lazy `duckplyr_df` objects (`tools/31-tpch-load-qs.R`)

The TPC-H tables were cached as lazy, DuckDB-backed `duckplyr_df` objects.
qs2 round-trips them into materialized frames
that keep the `duckplyr_df` class and explicit row names.
The benchmark then calls `as_duckdb_tibble()` on them,
which aborts with
`Need data frame without row names to convert to relational`.
Wrapping the read in `dplyr::collect()` stores plain tibbles instead.

### 3. Grant the comment workflow write permissions (`touchstone-comment.yaml`)

The `comment` action posts a PR comment and sets a commit status,
but the workflow declared no `permissions`,
so it fails under a read-only default `GITHUB_TOKEN`.
Added `pull-requests: write` and `statuses: write` (plus `contents: read`).

## Verification

Reproduced and fixed locally, end to end:
generate scale-factor TPC-H data with the DuckDB `tpch` extension,
cache it via qs2, reload, convert every table with `as_duckdb_tibble()`,
and run all 22 TPC-H benchmark queries — all 22 pass.
Before the fix, `as_duckdb_tibble()` aborted on the first table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011X3BjyMVghj28LNsZFPbG8)_